### PR TITLE
Adds dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# A Dockerfile to run https://github.com/microsoft/Tools-for-Health-Data-Anonymization
+# based loosely on https://github.com/microsoft/Tools-for-Health-Data-Anonymization/blob/master/release.yml
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 
+WORKDIR /source
+
+
+# copy src to container
+COPY . .
+
+# build a release
+
+RUN dotnet build --configuration Release FHIR/*.sln
+RUN dotnet publish --configuration Release FHIR/*.sln
+RUN dotnet pack FHIR/
+RUN dotnet publish  FHIR/ -r linux-x64
+
+# Run the executable we just produced
+RUN ./FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/bin/Release/netcoreapp3.1/publish/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool
+

--- a/aced.md
+++ b/aced.md
@@ -1,0 +1,21 @@
+## To run the command in the docker file
+
+./FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/bin/Release/netcoreapp3.1/publish/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool -i ./FHIR/samples/fhir-r4-files -o ./FHIR/samples/fhir-r4-files-output
+
+
+## Examine the results
+
+```
+root@378b3ab98367:/source# jq '.entry[] | select(.resource.resourceType == "Patient") | .resource.identifier[] | .value ' ./FHIR/samples/fhir-r4-files/Antonia30_Ruelas156_fe07e69a-4d6d-4e11-a675-de69f62de5f3.json
+"fe07e69a-4d6d-4e11-a675-de69f62de5f3"
+"fe07e69a-4d6d-4e11-a675-de69f62de5f3"
+"999-40-8244"
+"S99970618"
+"X74625645X"
+root@378b3ab98367:/source# jq '.entry[] | select(.resource.resourceType == "Patient") | .resource.identifier ' ./FHIR/samples/fhir-r4-files-output/Antonia30_Ruelas156_fe07e69a-4d6d-4e11-a675-de69f62de5f3.json
+nul
+
+```
+
+
+

--- a/configuration-sample.json
+++ b/configuration-sample.json
@@ -1,0 +1,19 @@
+{
+  "fhirVersion": "R4",
+  "processingError":"raise",
+  "fhirPathRules": [
+    {"path": "nodesByType('Extension')", "method": "redact"},
+    {"path": "Organization.identifier", "method": "keep"},
+    {"path": "Patient.identifier", "method": "redact"},
+    {"path": "nodesByType('Address').country", "method": "keep"},
+    {"path": "Resource.id", "method": "cryptoHash"},
+    {"path": "nodesByType('Reference').reference", "method": "cryptoHash"},
+    {"path": "Group.name", "method": "redact"}
+  ],
+  "parameters": {
+    "dateShiftKey": "",
+    "cryptoHashKey": "",
+    "encryptKey": "",
+    "enablePartialAgesForRedact": true
+  }
+}


### PR DESCRIPTION
This PR:
* Adds ability to declaratively redact incoming FHIR service to ACED
* Creates a dockerfile to enable .net based tool to run on linux or mac desktop
* Start of configuration file to implement policy based redaction

TODO:
Look at Google's list of fields any build out the configuration file.
https://cloud.google.com/healthcare-api/docs/how-tos/fhir-deidentify#default_fhir_de-identification_profile
